### PR TITLE
fix(openapi-client): various serialization misbehaviors

### DIFF
--- a/packages/openapi-client/lib/templates/_client.tpl.ts
+++ b/packages/openapi-client/lib/templates/_client.tpl.ts
@@ -46,7 +46,7 @@ export const _ = {
     /** Creates a tag-function to encode template strings with the given encoders. */
     encode(encoders: Encoders, delimiter = ","): TagFunction {
         return (strings: TemplateStringsArray, ...values: any[]) => {
-            return strings.reduce((prev, s, i) => `${prev}${s}${q(values[i] || "", i)}`, "");
+            return strings.reduce((prev, s, i) => `${prev}${s}${q(values[i] ?? "", i)}`, "");
         };
 
         function q(v: any, i: number): string {

--- a/packages/openapi-client/lib/templates/_client.tpl.ts
+++ b/packages/openapi-client/lib/templates/_client.tpl.ts
@@ -35,8 +35,8 @@ type MultipartRequestOptions = RequestOptions & {
 /** Utilities functions */
 export const _ = {
     // Encode param names and values as URIComponent
-    encodeReserved: [encodeURIComponent, encodeURIComponent],
-    allowReserved: [encodeURIComponent, encodeURI],
+    encodeReserved: [encodeURI, encodeURIComponent],
+    allowReserved: [encodeURI, encodeURI],
 
     /** Deeply remove all properties with undefined values. */
     stripUndefined<T>(obj?: T): T | undefined {
@@ -88,7 +88,7 @@ export const _ = {
 export const QS = {
     /** Join params using an ampersand and prepends a questionmark if not empty. */
     query(...params: string[]): string {
-        const s = params.join("&");
+        const s = params.filter(p => !!p).join("&");
         return s && `?${s}`;
     },
 
@@ -105,9 +105,10 @@ export const QS = {
             Object.entries(obj)
                 .filter(([, v]) => v !== undefined)
                 .map(([prop, v]) => {
-                    const index = Array.isArray(obj) ? "" : prop;
+                    const isValueObject = typeof v === "object";
+                    const index = Array.isArray(obj) && !isValueObject ? "" : prop;
                     const key = prefix ? qk`${prefix}[${index}]` : prop;
-                    if (typeof v === "object") {
+                    if (isValueObject) {
                         return visit(v, key);
                     }
                     return qv`${key}=${v}`;

--- a/packages/openapi-client/lib/templates/_client.tpl.ts
+++ b/packages/openapi-client/lib/templates/_client.tpl.ts
@@ -42,6 +42,12 @@ export const _ = {
     stripUndefined<T>(obj?: T): T | undefined {
         return obj && JSON.parse(JSON.stringify(obj));
     },
+    
+    isEmpty(v: unknown): boolean {
+        return typeof v === "object" && !!v ?
+            Object.keys(v).length === 0 && v.constructor === Object :
+            v === undefined;
+    },
 
     /** Creates a tag-function to encode template strings with the given encoders. */
     encode(encoders: Encoders, delimiter = ","): TagFunction {
@@ -70,7 +76,7 @@ export const _ = {
     delimited(delimiter = ","): (params: Record<string, any>, encoders?: Encoders) => string {
         return (params: Record<string, any>, encoders = _.encodeReserved) =>
             Object.entries(params)
-                .filter(([, value]) => value !== undefined)
+                .filter(([, value]) => !_.isEmpty(value))
                 .map(([name, value]) => _.encode(encoders, delimiter)`${name}=${value}`)
                 .join("&");
     },
@@ -103,7 +109,7 @@ export const QS = {
         // https://github.com/expressjs/body-parser/issues/289
         const visit = (obj: any, prefix = ""): string =>
             Object.entries(obj)
-                .filter(([, v]) => v !== undefined)
+                .filter(([, v]) => !_.isEmpty(v))
                 .map(([prop, v]) => {
                     const isValueObject = typeof v === "object";
                     const index = Array.isArray(obj) && !isValueObject ? "" : prop;


### PR DESCRIPTION
Bug: Query serialization in generated client omits `false` valued parameters, which makes an erroneous querystring

Fix: Replace _logical OR_ (`||`) with _nullish coalescing operator_ (`??`)