### PR TITLE
fix(jsonschema,openapi): cover more nested refs cases

### DIFF
--- a/packages/openapi/tests/assets/nested-api.yml
+++ b/packages/openapi/tests/assets/nested-api.yml
@@ -13,8 +13,14 @@ paths:
       responses:
         200:
           $ref: "#/components/responses/GetOneThingResponse"
-        202:
+        201:
           $ref: "#/components/responses/GetThingDataResponse"
+        202:
+          description: thing nested
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ThingNested"
 
 components:
   requestBodies:
@@ -37,3 +43,7 @@ components:
         application/json:
           schema:
             $ref: "nested/nested-schemas-2.yml#/components/schemas/ThingData"
+
+  schemas:
+    ThingNested:
+      $ref: "nested/nested-schemas-2.yml#/components/schemas/ThingNested"

--- a/packages/openapi/tests/assets/nested/nested-schemas-2.yml
+++ b/packages/openapi/tests/assets/nested/nested-schemas-2.yml
@@ -8,3 +8,8 @@ components:
           format: date-time
         value:
           type: integer
+    ThingNested:
+      type: object
+      properties:
+        nested:
+          $ref: "#/components/schemas/ThingData"

--- a/packages/openapi/tests/openapi-parser.spec.ts
+++ b/packages/openapi/tests/openapi-parser.spec.ts
@@ -106,12 +106,13 @@ describe("openapi-parser", () => {
             const schema = loadSpec("nested-api.yml");
             const { models } = await parseOpenApi(schema, { cwd: getAssetsPath() });
 
-            expect(models).toHaveLength(3);
+            expect(models).toHaveLength(4);
             expect(models[0]).toHaveProperty("name.text", "ThingKey");
             expect(models[1]).toHaveProperty("name.text", "ThingData");
             expect(models[2]).toHaveProperty("name.text", "Thing");
             expect(models[2]).toHaveProperty(["heritageClauses", 0, "types", 0, "expression", "escapedText"], "ThingKey");
             expect(models[2]).toHaveProperty(["heritageClauses", 0, "types", 1, "expression", "escapedText"], "ThingData");
+            expect(models[3]).toHaveProperty("name.text", "ThingNested");
         });
 
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:  
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #17 

## Types of changes. 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Which issue/s this PR fixes. 
fixes #15 #17

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
https://github.com/touchifyapp/spec2ts/blob/45b942c2f6f9d1543aa813c34dd96f2c1ab991ae/packages/openapi/tests/openapi-parser.spec.ts#L115

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/touchifyapp/spec2ts/blob/master/CONTRIBUTING.md) guide
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
